### PR TITLE
Remove deprecated svg animation directive

### DIFF
--- a/assets/loading.svg
+++ b/assets/loading.svg
@@ -1,12 +1,24 @@
 <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
    width="40px" height="40px" viewBox="0 0 50 50" style="enable-background:new 0 0 50 50;" xml:space="preserve">
-  <path fill="#989898" d="M25.251,6.461c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615V6.461z">
-    <animateTransform attributeType="xml"
-      attributeName="transform"
-      type="rotate"
-      from="0 25 25"
-      to="360 25 25"
-      dur="0.6s"
-      repeatCount="indefinite"/>
+  <style type="text/css" >
+    <![CDATA[
+    @keyframes spin {
+      0% {
+        transform: rotate(0deg);
+      }
+
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .spinner {
+      fill: #989898;
+      animation: spin 0.6s linear infinite;
+      transform-origin: 25px 25px;
+    }
+    ]]>
+  </style>
+  <path class="spinner" d="M25.251,6.461c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615V6.461z">
   </path>
 </svg>


### PR DESCRIPTION
This will suppress a warning in the console about svg animation
directives. Using CSS for the spinner instead.
