### PR TITLE
Set min and max for lux

### DIFF
--- a/openag-config.json
+++ b/openag-config.json
@@ -18,7 +18,9 @@
       "variable": "light_illuminance",
       "title": "Light",
       "unit": " Lux",
-      "color": "#ffc500"
+      "color": "#ffc500",
+      "min": 0.0001,
+      "max": 100000
     },
     {
       "variable": "air_temperature",


### PR DESCRIPTION
0.0001 lux is a deep moonless night full of spooky shadows.
100000 lux is direct sunlight.

See https://en.wikipedia.org/wiki/Lux
