### PR TITLE
Use pouchdb-browser custom build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "d3": "^4.0.0",
-    "pouchdb": "^5.3.1",
+    "pouchdb-browser": "^5.4.5",
     "reflex": "^0.4.1",
     "reflex-virtual-dom-driver": "^0.2.0",
     "whatwg-fetch": "^1.0.0"

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -1,6 +1,6 @@
 import {html, forward, Effects, Task, thunk} from 'reflex';
 import * as Config from '../openag-config.json';
-import PouchDB from 'pouchdb';
+import PouchDB from 'pouchdb-browser';
 import * as Template from './common/stache';
 import * as Database from './common/database';
 import * as Indexed from './common/indexed';


### PR DESCRIPTION
This leaves out the stuff that makes Pouch work in Node (we don't need that), and will create a file size savings when used with Rollup.
