### PR TITLE
fixed brain api url to use CouchDb proxy

### DIFF
--- a/openag-config.json
+++ b/openag-config.json
@@ -1,5 +1,5 @@
 {
-  "api": "{{root_url}}:5000/api/0.0.1",
+  "api": "{{root_url}}:5984/_openag/api/0.0.1",
   "origin": "{{root_url}}:5984",
   "heartbeat": "{{root_url}}:5984",
 


### PR DESCRIPTION
Based on discussion in https://github.com/OpenAgInitiative/openag_brain_docker_rpi/pull/12
