### PR TITLE
Rename classes to avoid name collision

### DIFF
--- a/scripts/environment/chart.js
+++ b/scripts/environment/chart.js
@@ -17,8 +17,8 @@ import {listByKeys, indexWith} from '../common/indexed';
 import {compose} from '../lang/functional';
 import {onWindow} from '../driver/virtual-dom';
 import {marker, isMarker, isRecipeStart, isRecipeEnd, readX, readY, readVariable} from '../environment/datapoints';
-import {Buffer} from '../environment/buffer';
-import {Group} from '../environment/group';
+import {FixedBuffer} from '../environment/fixed-buffer';
+import {LineGroup} from '../environment/line-group';
 import {SeriesView} from '../environment/series';
 
 const S_MS = 1000;
@@ -113,7 +113,7 @@ class Model {
 Model.isEmpty = model => {
   const tally = SeriesView.reduce(
     model.series,
-    (state, group) => state + Group.calcLength(group),
+    (state, group) => state + LineGroup.calcLength(group),
     0
   );
 
@@ -548,7 +548,7 @@ const viewGroup = (model, address, x, plotHeight) => {
     .y(compose(y, readY));
 
   const desiredPath = svgPath({
-    d: calcLine(Buffer.values(desired)),
+    d: calcLine(FixedBuffer.values(desired)),
     className: 'chart-desired',
     style: {
       stroke: color
@@ -556,7 +556,7 @@ const viewGroup = (model, address, x, plotHeight) => {
   });
 
   const measuredPath = svgPath({
-    d: calcLine(Buffer.values(measured)),
+    d: calcLine(FixedBuffer.values(measured)),
     className: 'chart-measured',
     style: {
       stroke: color
@@ -571,8 +571,8 @@ const viewGroup = (model, address, x, plotHeight) => {
 const renderReadout = (group, xhairTime) => {
   const unit = group.unit;
   const color = group.color;
-  const measured = Buffer.values(group.measured);
-  const desired = Buffer.values(group.desired);
+  const measured = FixedBuffer.values(group.measured);
+  const desired = FixedBuffer.values(group.desired);
   const measuredText = displayYValueFromX(measured, xhairTime, readX, readY, unit);
   const desiredText = displayYValueFromX(desired, xhairTime, readX, readY, unit);
 

--- a/scripts/environment/fixed-buffer.js
+++ b/scripts/environment/fixed-buffer.js
@@ -1,4 +1,4 @@
-export class Buffer {
+export class FixedBuffer {
   constructor(array, limit) {
     if (limit == null || limit < 1) {
       throw new Error('Buffer limit must be greater than 0');
@@ -22,7 +22,7 @@ export class Buffer {
   advance(datum) {
     // Add datum to end of array.
     const next = advanceBufferMut(this.buffer.slice(), this.limit, datum);
-    return new Buffer(next, this.limit);
+    return new FixedBuffer(next, this.limit);
   }
 
   advanceManyMut(data) {
@@ -35,7 +35,7 @@ export class Buffer {
   advanceMany(data) {
     if (data.length) {
       const next = trimMut(this.buffer.concat(data), this.limit);
-      return new Buffer(next, this.limit);
+      return new FixedBuffer(next, this.limit);
     }
     else {
       return this;
@@ -43,12 +43,12 @@ export class Buffer {
   }
 }
 
-Buffer.from = (array, limit) => new Buffer(trimMut(array.slice(), limit), limit);
+FixedBuffer.from = (array, limit) => new FixedBuffer(trimMut(array.slice(), limit), limit);
 
 // Returns the array from buffer.
 // @NOTE NEVER MUTATE THIS VALUE DIRECTLY. Always use the provided methods
 // on Buffer.
-Buffer.values = buffer => buffer.buffer;
+FixedBuffer.values = buffer => buffer.buffer;
 
 // Advance a sorted buffer and mutate it.
 const advanceBufferMut = (buffer, limit, datum) => {

--- a/scripts/environment/line-group.js
+++ b/scripts/environment/line-group.js
@@ -2,11 +2,11 @@
 Exports the Group class, which is used for chart groups.
 */
 import last from 'lodash/last';
-import {Buffer} from '../environment/buffer';
+import {FixedBuffer} from '../environment/fixed-buffer';
 import {readX} from '../environment/datapoints';
 
 // Construct a chart group
-export class Group {
+export class LineGroup {
   constructor(
     // Measured and desired should ALWAYS be sorted descending by readX.
     measured,
@@ -47,7 +47,7 @@ export class Group {
   }
 
   swap(measured, desired) {
-    return new Group(
+    return new LineGroup(
       measured,
       desired,
       this.variable,
@@ -95,7 +95,7 @@ export class Group {
 
 // Assemble a new group from 2 arrays and config.
 // Returns a new group instance.
-Group.assemble = (
+LineGroup.assemble = (
   measured,
   desired,
   variable,
@@ -105,9 +105,9 @@ Group.assemble = (
   max,
   color,
   limit
-) => new Group(
-  new Buffer(measured, limit),
-  new Buffer(desired, limit),
+) => new LineGroup(
+  new FixedBuffer(measured, limit),
+  new FixedBuffer(desired, limit),
   variable,
   title,
   unit,
@@ -116,7 +116,7 @@ Group.assemble = (
   color
 );
 
-Group.calcLength = group => (
-  Buffer.values(group.measured).length +
-  Buffer.values(group.desired).length
+LineGroup.calcLength = group => (
+  FixedBuffer.values(group.measured).length +
+  FixedBuffer.values(group.desired).length
 );

--- a/scripts/environment/series.js
+++ b/scripts/environment/series.js
@@ -1,6 +1,6 @@
 import zipObject from 'lodash/zipObject';
 import defaults from 'lodash/defaults';
-import {Group} from '../environment/group';
+import {LineGroup} from '../environment/line-group';
 
 // Constructs a series of groups.
 // Note that direct construction via constructor function isn't very useful,
@@ -19,7 +19,7 @@ export class Series {
     const group = this.index[datum.variable];
     if (group) {
       const variable = readConfigVariable(group);
-      return new Group(
+      return new LineGroup(
         defaults({[variable]: group.advance(datum)}, group.index),
         group.order
       );
@@ -55,7 +55,7 @@ Series.from = (array, configs, limit) => {
   const keys = configs.map(readConfigVariable);
 
   // Construct an array of empty group instances for each config object.
-  const instances = configs.map(config => Group.assemble(
+  const instances = configs.map(config => LineGroup.assemble(
     [],
     [],
     config.variable,


### PR DESCRIPTION
e.g. with native Buffer.
