### PR TITLE
Start recipe improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .DS_Store
+npm-debug.log

--- a/openag-config.json
+++ b/openag-config.json
@@ -5,6 +5,7 @@
 
   "active_environment": "environment_1",
   "start_recipe_url": "{{api_url}}/service/{{environment}}/start_recipe",
+  "stop_recipe_url": "{{api_url}}/service/{{environment}}/stop_recipe",
 
   "environmental_data_point": {
     "local": "environmental_data_point",

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -333,12 +333,12 @@ const postStopStartRecipe = (model, environmentID, id) => {
   ];
 }
 
-const recipePostedOk = (model, value, action) => {
+const recipePostedOk = (model, value) => {
   const message = localize('Recipe started!');
   return update(model, NotifyBanner(message));
 }
 
-const recipePostedError = (model, error, action) => {
+const recipePostedError = (model, error) => {
   const message = localize('Food computer was unable to start recipe');
   return update(model, AlertRefreshableBanner(message));
 }

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -145,8 +145,8 @@ const PostStopRecipe = (environmentID) => ({
   environmentID
 });
 
-const RecipePosted = (result) => ({
-  type: 'RecipePosted',
+const RecipeStartPosted = (result) => ({
+  type: 'RecipeStartPosted',
   result
 });
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -241,8 +241,8 @@ export const update = (model, action) =>
   action.type === 'RecipeStartPosted' ?
   (
     action.result.isOk ?
-    recipePostedOk(model, action.result.value, 'Started!') :
-    recipePostedError(model, action.result.error, 'start')
+    recipePostedOk(model, action.result.value) :
+    recipePostedError(model, action.result.error)
   ) :
   action.type === 'SaveState' ?
   saveState(model) :
@@ -334,12 +334,12 @@ const postStopStartRecipe = (model, environmentID, id) => {
 }
 
 const recipePostedOk = (model, value, action) => {
-  const message = localize('Recipe '+action+'!');
+  const message = localize('Recipe started!');
   return update(model, NotifyBanner(message));
 }
 
 const recipePostedError = (model, error, action) => {
-  const message = localize('Food computer was unable to '+action+' recipe');
+  const message = localize('Food computer was unable to start recipe');
   return update(model, AlertRefreshableBanner(message));
 }
 


### PR DESCRIPTION
It was not possible to restart or switch to a different recipe if there is recipe running already. This change will call stop_recipe first and then follow up with start_recipe. 
Please mind that openag_brains [stop_recipe implementation change](https://github.com/OpenAgInitiative/openag_brain/pull/54) is needed to have this code work correctly. 
