### PR TITLE
Fix should_update logic

### DIFF
--- a/scripts/environment/chart/line-group.js
+++ b/scripts/environment/chart/line-group.js
@@ -33,7 +33,7 @@ export class LineGroup {
   shouldUpdate(datum) {
     if (datum.variable === this.variable) {
       const buffer = datum.is_desired ? this.desired : this.measured;
-      const prev = last(this.desired);
+      const prev = last(buffer);
       if (!prev) {
         return true;
       }


### PR DESCRIPTION
Previously, this logic would always end up returning true for cases
where a recipe wasn't running. Typo bug.