### PR TITLE
Fix start recipe

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -339,7 +339,7 @@ const postStartRecipe = (model, environmentID, recipeID) => {
 
   return [
     model,
-    Request.post(url, {recipe_id: recipeID}).map(RecipeStartPosted)
+    Request.post(url, [recipeID]).map(RecipeStartPosted)
   ];
 }
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -69,6 +69,8 @@ const SaveState = {type: 'SaveState'};
 const TagRecipes = action =>
   action.type === 'RequestStart' ?
   StartRecipe(action.id, action.name) :
+  action.type === 'RequestStopStart' ?
+  StopStartRecipe(action.id, action.name) :
   tagged('Recipes', action);
 
 const ConfigureRecipes = compose(TagRecipes, Recipes.Configure);
@@ -135,6 +137,12 @@ const NotifyBanner = compose(TagBanner, Banner.Notify);
 
 const StartRecipe = (id, name) => ({
   type: 'StartRecipe',
+  id,
+  name
+});
+
+const StopStartRecipe = (id, name) => ({
+  type: 'StopStartRecipe',
   id,
   name
 });
@@ -244,6 +252,8 @@ export const update = (model, action) =>
   configureFirstTime(model, action.form) :
   action.type === 'StartRecipe' ?
   startRecipe(model, action.id, action.name) :
+  action.type === 'StopStartRecipe' ?
+  stopStartRecipe(model, action.id, action.name) :
   action.type === 'PostStartRecipe' ?
   postStartRecipe(model, action.environmentID, action.recipeID) :
   action.type === 'PostStopStartRecipe' ?
@@ -326,8 +336,15 @@ const activateState = (model, id) =>
 
 const startRecipe = (model, id, name) =>
   batch(update, model, [
+    PostStartRecipe(model.environment.id, id),
     SetRecipeForEnvironment(id, name),
+    CloseRecipes
+  ]);
+
+const stopStartRecipe = (model, id, name) =>
+  batch(update, model, [
     PostStopStartRecipe(model.environment.id, id),
+    SetRecipeForEnvironment(id, name),
     CloseRecipes
   ]);
 

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -103,6 +103,12 @@ export const RequestStart = (id, name) => ({
   name
 });
 
+export const RequestStopStart = (id, name) => ({
+  type: 'RequestStopStart',
+  id,
+  name
+});
+
 const ActivatePanel = id => ({
   type: 'ActivatePanel',
   id
@@ -208,7 +214,9 @@ const startByID = (model, id) => {
     next,
     Effects.batch([
       fx,
-      Effects.receive(RequestStart(id, name))
+      model.active === null ?
+      Effects.receive(RequestStart(id, name)) :
+      Effects.receive(RequestStopStart(id, name))
     ])
   ];
 }


### PR DESCRIPTION
Addresses #124 

The API expects an array of parameters, as it the same endpoint is used to call any ROS Service. I updated the POST body to that schema.

Additionally, if there is no active recipe when a new one is started, the UI briefly shows an error, as calling the stop_recipe service fails. I attempted to fix it by doing this: if there is no active recipe, just start the new one; otherwise stop the active one and then start the new one.
