### PR TITLE
Remove lux from chart

### DIFF
--- a/openag-config.json
+++ b/openag-config.json
@@ -42,14 +42,6 @@
 
   "chart": [
     {
-      "variable": "light_illuminance",
-      "title": "Light",
-      "unit": " Lux",
-      "color": "#ffc500",
-      "min": 0.0001,
-      "max": 100000
-    },
-    {
       "variable": "air_carbon_dioxide",
       "title": "Air CO2",
       "unit": " ppm",


### PR DESCRIPTION
We no longer spec a light sensor, so we should remove the chart line.