### PR TITLE
Hit recipes DB directly

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -1011,6 +1011,24 @@ p {
   box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.12), 0px 1px 2px 0px rgba(0,0,0,0.24);
 }
 
+/* Progress - loading bar
+----------------------------------------------------------------------------- */
+
+.progress {
+  height: 12px;
+  background: blue;
+  position: absolute;
+  width: 100%;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity 200ms linear;
+  pointer-events: none;
+}
+
+.progress-is-loading {
+  opacity: 1;
+}
+
 /* FTU - First Time Use
 ----------------------------------------------------------------------------- */
 

--- a/assets/main.css
+++ b/assets/main.css
@@ -1015,18 +1015,29 @@ p {
 ----------------------------------------------------------------------------- */
 
 .progress {
+  background: url(stripes-dark-blue.png) repeat left center #00a5ed;
+  background-size: auto 40px;
+  animation: 1000ms linear 0ms infinite progress-crawl;
   height: 12px;
-  background: blue;
   position: absolute;
   width: 100%;
   z-index: 10;
   opacity: 0;
-  transition: opacity 200ms linear;
+  transition: opacity 160ms linear;
   pointer-events: none;
 }
 
 .progress-is-loading {
   opacity: 1;
+}
+
+@keyframes progress-crawl {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 86px 0;
+  }
 }
 
 /* FTU - First Time Use

--- a/openag-config.json
+++ b/openag-config.json
@@ -13,6 +13,7 @@
     "origin_range": "{{origin_url}}/environmental_data_point/_design/openag/_view/by_timestamp?startkey={{startkey}}&endkey={{endkey}}&limit={{limit}}&descending={{descending}}&stale=update_after",
     "origin_by_variable_csv": "{{origin_url}}/environmental_data_point/_design/openag/_list/csv/by_variable?group_level={{group_level}}&startkey={{startkey}}&endkey={{endkey}}&limit={{limit}}&descending={{descending}}&stale=update_after",
     "timelapse": "{{origin_url}}/environmental_data_point/{{recipe_start_id}}/timelapse",
+    "image": "{{origin_url}}/environmental_data_point/{{id}}/image",
     "changes": "{{origin_url}}/environmental_data_point/_changes?feed=longpoll&include_docs=true&heartbeat=true&since=now"
   },
 
@@ -35,7 +36,7 @@
     "state_id": "state",
     "default_state": "chart",
     "show_nav": true,
-    "show_dashboard": false,
+    "show_dashboard": true,
     "show_chart": true,
     "show_controls": true
   },

--- a/openag-config.json
+++ b/openag-config.json
@@ -1,5 +1,5 @@
 {
-  "root_url": "http://98.202.80.100",
+  "root_url": null,
   "origin_url": "{{root_url}}:5984",
   "api_url": "{{origin_url}}/_openag/api/0.0.1",
   "start_recipe_url": "{{api_url}}/service/environments/{{environment}}/start_recipe",

--- a/openag-config.json
+++ b/openag-config.json
@@ -23,6 +23,7 @@
   "recipes": {
     "local": "recipes",
     "origin": "{{origin_url}}/recipes",
+    "doc": "{{origin_url}}/recipes/{{id}}",
     "all_docs": "{{origin_url}}/recipes/_all_docs?include_docs=true"
   },
 

--- a/openag-config.json
+++ b/openag-config.json
@@ -21,7 +21,6 @@
   },
 
   "recipes": {
-    "local": "recipes",
     "origin": "{{origin_url}}/recipes",
     "doc": "{{origin_url}}/recipes/{{id}}",
     "all_docs": "{{origin_url}}/recipes/_all_docs?include_docs=true"

--- a/openag-config.json
+++ b/openag-config.json
@@ -6,7 +6,7 @@
   "stop_recipe_url": "{{api_url}}/service/environments/{{environment}}/stop_recipe",
 
   "demo": {
-    "image_url": "{{root_url}}/img.jpg"
+    "image_url": "{{root_url}}/img.jpg?timestamp={{timestamp}}"
   },
 
   "environmental_data_point": {

--- a/openag-config.json
+++ b/openag-config.json
@@ -22,7 +22,8 @@
 
   "recipes": {
     "local": "recipes",
-    "origin": "{{origin_url}}/recipes"
+    "origin": "{{origin_url}}/recipes",
+    "all_docs": "{{origin_url}}/recipes/_all_docs?include_docs=true"
   },
 
   "environments": {

--- a/openag-config.json
+++ b/openag-config.json
@@ -1,10 +1,13 @@
 {
-  "root_url": "",
-
-  "api_url": "{{root_url}}/_openag/api/0.0.1",
-  "origin_url": "{{root_url}}",
+  "root_url": "http://98.202.80.100",
+  "origin_url": "{{root_url}}:5984",
+  "api_url": "{{origin_url}}/_openag/api/0.0.1",
   "start_recipe_url": "{{api_url}}/service/environments/{{environment}}/start_recipe",
   "stop_recipe_url": "{{api_url}}/service/environments/{{environment}}/stop_recipe",
+
+  "demo": {
+    "image_url": "{{root_url}}/img.jpg"
+  },
 
   "environmental_data_point": {
     "local": "environmental_data_point",
@@ -34,7 +37,7 @@
   "app": {
     "local": "openag",
     "state_id": "state",
-    "default_state": "chart",
+    "default_state": "dashboard",
     "show_nav": true,
     "show_dashboard": true,
     "show_chart": true,

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -16,9 +16,10 @@ import * as Environment from './environment';
 import * as Recipes from './recipes';
 import {compose} from './lang/functional';
 
-const _url_template = {root_url: Config.root_url || window.location.origin};
-const API_URL = Template.render(Config.api_url, _url_template);
-const ORIGIN_URL = Template.render(Config.origin_url, _url_template);
+
+const ROOT_URL = readRootUrl(Config.root_url || window.location.origin);
+const ORIGIN_URL = Template.render(Config.origin_url, {root_url: ROOT_URL});
+const API_URL = Template.render(Config.api_url, {origin_url: ORIGIN_URL});
 // @FIXME we hardcode active environment for the moment. This works because
 // personal food computers manage just one environment. This should be
 // kept in the app state instead. We can pick a default, but let the user
@@ -152,6 +153,7 @@ export const init = () => {
   const configure = Configure({
     api: API_URL,
     origin: ORIGIN_URL,
+    root: ROOT_URL,
     environmentID: ENVIRONMENT_ID,
     environmentName: ENVIRONMENT_NAME
   });
@@ -309,7 +311,7 @@ const recipePostedError = (model, error) => {
   return update(model, AlertDismissableBanner(message));
 }
 
-const configure = (model, {api, origin, environmentID, environmentName}) => {
+const configure = (model, {api, origin, root, environmentID, environmentName}) => {
   // Restore serialized data from stored record.
   // Merge into in-memory app model.
   const next = merge(model, {
@@ -319,7 +321,7 @@ const configure = (model, {api, origin, environmentID, environmentName}) => {
 
   return batch(update, next, [
     ConfigureAppNav(environmentName),
-    ConfigureEnvironment(environmentID, environmentName, api, origin),
+    ConfigureEnvironment(environmentID, environmentName, root, api, origin),
     ConfigureEnvironments(origin),
     ConfigureRecipes(origin)
   ]);

--- a/scripts/common/database.js
+++ b/scripts/common/database.js
@@ -3,6 +3,8 @@
 import {Effects, Task} from 'reflex';
 import * as Result from '../common/result';
 import {compose} from '../lang/functional';
+import reject from 'lodash/reject';
+import map from 'lodash/map';
 
 export const Get = id => ({
   type: 'Get',
@@ -55,8 +57,10 @@ export const Restored = result => ({
 });
 
 // Mapping functions to just get the docs from an allDocs response.
-const readDocFromRow = row => row.doc;
-const readDocs = database => database.rows.map(readDocFromRow);
+export const readDocFromRow = row => row.doc;
+export const isDesignDoc = doc => doc._id.indexOf('_design/') !== -1;
+export const readAllDocs = database =>
+  reject(map(database.rows, readDocFromRow), isDesignDoc);
 
 // Request in-memory restore from DB
 // Returns an effect.
@@ -71,7 +75,7 @@ export const restore = db =>
         startkey: 'design_\uffff'
       })
       .then(
-        compose(Result.ok, readDocs),
+        compose(Result.ok, readAllDocs),
         Result.error
       )
       .then(succeed);

--- a/scripts/common/indexed.js
+++ b/scripts/common/indexed.js
@@ -77,6 +77,18 @@ export const add = (model, id, entry) =>
     })
   });
 
+export const insert = (model, id, entry, compare) => {
+  const order = [id, ...model.order];
+  order.sort(compare);
+  return merge(model, {
+    // Prepend new recipe id
+    order,
+    entries: merge(model.entries, {
+      [id]: entry
+    })
+  });
+}
+
 // Given a view function and an action tagging factory function, will return
 // a view that will list out all sub-views.
 export const children = (view, tagByID) => (model, address) =>
@@ -130,5 +142,14 @@ export const updateWithID = (update, tag, model, id, action) => {
       merge(model, {entries: merge(model.entries, {[id]: entry})}),
       fx.map(tag)
     ];
+  }
+}
+
+export const compareById = (a) => {
+  if (a > b) {
+    return 1;
+  }
+  else {
+    return -1;
   }
 }

--- a/scripts/common/indexed.js
+++ b/scripts/common/indexed.js
@@ -144,12 +144,3 @@ export const updateWithID = (update, tag, model, id, action) => {
     ];
   }
 }
-
-export const compareValue = (a, b) => {
-  if (a > b) {
-    return 1;
-  }
-  else {
-    return -1;
-  }
-}

--- a/scripts/common/indexed.js
+++ b/scripts/common/indexed.js
@@ -145,7 +145,7 @@ export const updateWithID = (update, tag, model, id, action) => {
   }
 }
 
-export const compareById = (a) => {
+export const compareValue = (a, b) => {
   if (a > b) {
     return 1;
   }

--- a/scripts/common/outbox.js
+++ b/scripts/common/outbox.js
@@ -1,0 +1,56 @@
+/*
+This module creates an outbox for outgoing requests that will need to be
+retried if they fail.
+*/
+import {Effects} from 'reflex';
+import * as Unknown from '../common/unknown';
+import {merge} from '../common/prelude';
+
+// Re-export values from loadash. We need a method to get an array of values
+// from the outbox. By re-exporting, we leave open the option of changing the
+// data structure later without changing the API.
+export {default as values} from 'lodash/values';
+
+// Get value at ID.
+// By exporting this function, we leave open the option of changing the
+// data structure later.
+export const get = (model, id) => model[id];
+
+// Add to the outbox
+export const Add = (id, value) => ({
+  type: 'Add',
+  id,
+  value
+});
+
+// Remove from outbox
+export const Remove = id => ({
+  type: 'Remove',
+  id
+});
+
+export const init = () => [
+  {},
+  Effects.none
+];
+
+export const update = (model, action) =>
+  action.type === 'Add' ?
+  add(model, action.id, action.value) :
+  action.type === 'Remove' ?
+  remove(model, action.id) :
+  Unknown.update(model, action);
+
+const add = (model, id, value) => [
+  merge(model, {
+    [id]: value
+  }),
+  Effects.none
+];
+
+const remove = (model, id, value) => [
+  merge(model, {
+    [id]: void(0)
+  }),
+  Effects.none
+];

--- a/scripts/common/progress.js
+++ b/scripts/common/progress.js
@@ -1,0 +1,34 @@
+/*
+Shared module for creating loading progress bars.
+*/
+import {html, forward, Effects, thunk} from 'reflex';
+import {merge} from './prelude';
+import {classed} from './attr';
+import {cursor} from './cursor';
+import {update as updateUnknown} from './unknown';
+
+// Loading/loaded actions hide and show the progress bar.
+export const Loading = {type: 'Loading'};
+export const Loaded = {type: 'Loaded'};
+
+export const init = () => [
+  {
+    isLoading: false
+  },
+  Effects.none
+];
+
+export const update = (model, action) =>
+  action.type === 'Loading' ?
+  [merge(model, {isLoading: true}), Effects.none] :
+  action.type === 'Loaded' ?
+  [merge(model, {isLoading: false}), Effects.none] :
+  updateUnknown(model, action);
+
+export const view = (model, address) =>
+  html.div({
+    className: classed({
+      'progress': true,
+      'progress-is-loading': model.isLoading
+    })
+  });

--- a/scripts/common/request.js
+++ b/scripts/common/request.js
@@ -47,24 +47,33 @@ const readResponseJSON = response =>
 const readFailure = error =>
   Result.error(localize('Uh-oh! No response from the server.'));
 
-const getFetch = url => {
-  const headers = new Headers({
-    'Content-Type': 'application/json',
-  });
+// Create an instance of JSON headers for the Request helper functions below
+// to share.
+const JSON_HEADERS = new Headers({
+  'Content-Type': 'application/json',
+});
+
+const requestGet = url => {
   const request = new Request(url, {
     method: 'GET',
-    headers
+    headers: JSON_HEADERS
   });
   return fetch(request).then(readResponseJSON, readFailure);
 }
 
-const postFetch = (url, body) => {
-  const headers = new Headers({
-    'Content-Type': 'application/json',
-  });
+const requestPost = (url, body) => {
   const request = new Request(url, {
     method: 'POST',
-    headers,
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body)
+  });
+  return fetch(request).then(readResponseJSON, readFailure);
+}
+
+const requestPut = (url, body) => {
+  const request = new Request(url, {
+    method: 'PUT',
+    headers: JSON_HEADERS,
     body: JSON.stringify(body)
   });
   return fetch(request).then(readResponseJSON, readFailure);
@@ -74,12 +83,19 @@ const postFetch = (url, body) => {
 // You'll want to use the `.map()` method on the return value to map this
 // into an action.
 export const get = url => Effects.perform(new Task(succeed => {
-  getFetch(url).then(succeed);
+  requestGet(url).then(succeed);
 }));
 
 // Returns post effect
 // You'll want to use the `.map()` method on the return value to map this
 // into an action.
 export const post = (url, body) => Effects.perform(new Task(succeed => {
-  postFetch(url, body).then(succeed);
+  requestPost(url, body).then(succeed);
+}));
+
+// Returns put effect
+// You'll want to use the `.map()` method on the return value to map this
+// into an action.
+export const put = (url, body) => Effects.perform(new Task(succeed => {
+  requestPut(url, body).then(succeed);
 }));

--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -8,7 +8,7 @@ import * as Result from './common/result';
 import * as Unknown from './common/unknown';
 import {cursor} from './common/cursor';
 import {constant, compose} from './lang/functional';
-import {findRunningRecipe, findAirTemperature} from './environment/doc';
+import {findRunningRecipe, findAirTemperature, findAerialImage} from './environment/doc';
 import * as Chart from './environment/chart';
 import * as Dashboard from './environment/dashboard';
 import * as Controls from './environment/controls';
@@ -84,6 +84,7 @@ const DashboardAction = action => ({
   source: action
 });
 
+const UpdateAerialImage = compose(DashboardAction, Dashboard.UpdateAerialImage);
 const ConfigureDashboard = compose(DashboardAction, Dashboard.Configure);
 const SetDashboardRecipe = compose(DashboardAction, Dashboard.SetRecipe);
 const decodeDashboardRecipe = compose(DashboardAction, Dashboard.decodeRecipe);
@@ -213,6 +214,11 @@ const updateBacklog = Result.updater(
       actions.push(SetDashboardAirTemperature(airTemperature));
     }
 
+    const aerialImage = findAerialImage(data);
+    if (aerialImage) {
+      actions.push(UpdateAerialImage(aerialImage));
+    }
+
     actions.push(GetChanges);
 
     return batch(update, model, actions);
@@ -265,6 +271,11 @@ const gotChangesOk = (model, record) => {
   const airTemperature = findAirTemperature(data);
   if (airTemperature) {
     actions.push(SetDashboardAirTemperature(airTemperature));
+  }
+
+  const aerialImage = findAerialImage(data);
+  if (aerialImage) {
+    actions.push(UpdateAerialImage(aerialImage));
   }
 
   actions.push(GetChanges);

--- a/scripts/environment.js
+++ b/scripts/environment.js
@@ -44,8 +44,9 @@ export const ActivateState = id => ({
 });
 
 // Configure action received from parent.
-export const Configure = (environmentID, environmentName, api, origin) => ({
+export const Configure = (environmentID, environmentName, root, api, origin) => ({
   type: 'Configure',
+  root,
   api,
   origin,
   id: environmentID,
@@ -293,7 +294,7 @@ const gotChangesError = (model, error) => {
   ];
 }
 
-const configure = (model, {api, origin, id, name}) => {
+const configure = (model, {root, api, origin, id, name}) => {
   const next = merge(model, {
     origin,
     id,
@@ -305,7 +306,7 @@ const configure = (model, {api, origin, id, name}) => {
   return batch(update, next, [
     // Forward configuration down to submodules.
     ConfigureChart(origin),
-    ConfigureDashboard(origin),
+    ConfigureDashboard(root, origin),
     ConfigureControls(api, id),
     // Now that we have the origin, get the backlog.
     GetBacklog

--- a/scripts/environment/dashboard.js
+++ b/scripts/environment/dashboard.js
@@ -1,16 +1,18 @@
 /*
 The dashboard displays the latest camera information from the Food Computer.
 */
-import {html, forward, Effects, thunk} from 'reflex';
+import {html, forward, Effects, Task, thunk} from 'reflex';
 import {
   environmental_data_point as ENVIRONMENTAL_DATA_POINT,
   demo as DEMO
 } from '../../openag-config';
-import {compose} from '../lang/functional';
+import {compose, constant} from '../lang/functional';
 import {render as renderTemplate} from '../common/stache';
 import {update as updateUnknown} from '../common/unknown';
 import {localize} from '../common/lang';
 import * as Sidebar from './dashboard/sidebar';
+
+const REFRESH_TIMEOUT = 30 * 1000;
 
 // Actions
 
@@ -70,10 +72,14 @@ const SidebarAction = action => ({
 const SetSidebarRecipe = compose(SidebarAction, Sidebar.SetRecipe);
 export const SetAirTemperature = compose(SidebarAction, Sidebar.SetAirTemperature);
 
+const RefreshImg = {type: 'RefreshImg'};
+const AlwaysRefreshImg = constant(RefreshImg);
+
 // Init and update
 
 class Model {
   constructor(
+    timestamp,
     root,
     origin,
     recipeStartID,
@@ -82,6 +88,7 @@ class Model {
     sidebar,
     imageID
   ) {
+    this.timestamp = timestamp;
     this.root = root;
     this.origin = origin;
     this.recipeStartID = recipeStartID;
@@ -104,6 +111,7 @@ export const init = () => {
 
   return [
     new Model(
+      Date.now(),
       null,
       null,
       null,
@@ -112,13 +120,16 @@ export const init = () => {
       sidebar,
       null
     ),
-    Effects.none
+    Effects.receive(RefreshImg)
   ];
 }
 
 export const update = (model, action) =>
   action.type === 'UpdateAerialImage' ?
-  swapImageID(model, action.doc._id) :
+  // @HACK for wfp demo... pass
+  [model, Effects.none] :
+  action.type === 'RefreshImg' ?
+  refreshImg(model) :
   action.type === 'Sidebar' ?
   delegateSidebarUpdate(model, action.source) :
   action.type === 'SetRecipe' ?
@@ -128,11 +139,6 @@ export const update = (model, action) =>
   action.type === 'FinishLoading' ?
   finishLoading(model) :
   updateUnknown(model, action);
-
-const updateAerialImage = (model, doc) => {
-
-}
-
 
 const setRecipe = (model, id, name) => {
   // Update sidebar model with id and name
@@ -145,6 +151,7 @@ const setRecipe = (model, id, name) => {
 
   // Create new model with id and new sidebar model
   const next = new Model(
+    model.timestamp,
     model.root,
     model.origin,
     id,
@@ -161,6 +168,7 @@ const setRecipe = (model, id, name) => {
 // Configure origin url on model
 const configure = (model, root, origin) => [
   new Model(
+    model.timestamp,
     root,
     origin,
     model.recipeStartID,
@@ -175,6 +183,7 @@ const configure = (model, root, origin) => [
 // Flag initial loading state as finished.
 const finishLoading = model => [
   new Model(
+    model.timestamp,
     model.root,
     model.origin,
     model.recipeStartID,
@@ -187,8 +196,23 @@ const finishLoading = model => [
   Effects.none
 ];
 
+const refreshImg = (model) => [
+  new Model(
+    Date.now(),
+    model.root,
+    model.origin,
+    model.recipeStartID,
+    model.hasTimelapse,
+    model.isLoading,
+    model.sidebar,
+    model.imageID
+  ),
+  Effects.perform(Task.sleep(REFRESH_TIMEOUT)).map(AlwaysRefreshImg)
+];
+
 const swapImageID = (model, imageID) => [
   new Model(
+    model.timestamp,
     model.root,
     model.origin,
     model.recipeStartID,
@@ -198,10 +222,11 @@ const swapImageID = (model, imageID) => [
     imageID
   ),
   Effects.none
-]
+];
 
 const swapSidebar = (model, [sidebar, fx]) => [
   new Model(
+    model.timestamp,
     model.root,
     model.origin,
     model.recipeStartID,
@@ -221,8 +246,6 @@ const delegateSidebarUpdate = (model, action) =>
 export const view = (model, address) =>
   model.isLoading ?
   viewLoading(model, address) :
-  !model.imageID ?
-  viewEmpty(model, address) :
   viewReady(model, address);
 
 const viewReady = (model, address) =>
@@ -295,7 +318,8 @@ const viewEmpty = (model, address) =>
 // Utils
 const templateImgUrl = model =>
   renderTemplate(DEMO.image_url, {
-    root_url: model.root
+    root_url: model.root,
+    timestamp: model.timestamp
   });
 
 const templateVideoUrl = model =>

--- a/scripts/environment/dashboard.js
+++ b/scripts/environment/dashboard.js
@@ -2,7 +2,11 @@
 The dashboard displays the latest camera information from the Food Computer.
 */
 import {html, forward, Effects, thunk} from 'reflex';
-import {environmental_data_point as ENVIRONMENTAL_DATA_POINT} from '../../openag-config';
+import {
+  environmental_data_point as ENVIRONMENTAL_DATA_POINT,
+  demo as DEMO,
+  root_url as ROOT_URL
+} from '../../openag-config';
 import {compose} from '../lang/functional';
 import {render as renderTemplate} from '../common/stache';
 import {update as updateUnknown} from '../common/unknown';
@@ -282,9 +286,8 @@ const viewEmpty = (model, address) =>
 
 // Utils
 const templateImgUrl = model =>
-  renderTemplate(ENVIRONMENTAL_DATA_POINT.image, {
-    origin_url: model.origin,
-    id: model.imageID
+  renderTemplate(DEMO.image_url, {
+    root_url: ROOT_URL
   });
 
 const templateVideoUrl = model =>

--- a/scripts/environment/doc.js
+++ b/scripts/environment/doc.js
@@ -9,6 +9,7 @@ export const RECIPE_START = 'recipe_start';
 export const RECIPE_END = 'recipe_end';
 export const AIR_TEMPERATURE = 'air_temperature';
 export const MARKER = 'marker';
+export const AERIAL_IMAGE = 'aerial_image';
 
 // X and Y accessors for documents.
 // Timestamp is unix epoch in seconds.
@@ -21,6 +22,10 @@ export const variable = doc => doc.variable;
 
 export const isRecipeStart = dataPoint => dataPoint.variable === RECIPE_START;
 export const isRecipeEnd = dataPoint => dataPoint.variable === RECIPE_END;
+
+// Check if a database document is of type aerial image.
+export const isAerialImage = doc => doc.variable === AERIAL_IMAGE;
+
 
 export const isRecipeRunning = (recipeStart, recipeEnd) => {
   // If we have both a recipe start and a recipe end, check that the recipe
@@ -40,6 +45,7 @@ export const isRecipeRunning = (recipeStart, recipeEnd) => {
 // more efficient, given our list is sorted.
 export const findRecipeStart = data => findLast(data, isRecipeStart);
 export const findRecipeEnd = data => findLast(data, isRecipeEnd);
+export const findAerialImage = data => findLast(data, isAerialImage);
 
 // Given a list of datapoints, find a running recipe (if any) within them.
 export const findRunningRecipe = data => {

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -173,7 +173,7 @@ const sync = model => {
   // @NOTE the strict equality check is important, since origin is allowed
   // to be an empty string!
   if (model.origin !== null) {
-    const origin = templateRecipesDatabase(model.origin);
+    const origin = templateRecipesDb(model.origin);
     return [model, Database.sync(DB, origin).map(Synced)];
   }
   else {
@@ -233,16 +233,15 @@ const startByID = (model, id) => {
 const activatePanel = (model, id) =>
   [merge(model, {activePanel: id}), Effects.none];
 
-const put = (model, doc) => {
-  // Attempt to store it in DB.
-  return [model, Database.put(DB, doc).map(Putted)];
-}
+const put = (model, doc) => [
+  model,
+  Request.put(templateRecipePut(model.origin, doc._id), doc).map(Putted)
+];
 
 const puttedOk = (model, value) =>
   batch(update, model, [
     ClearRecipesForm,
     RestoreRecipes,
-    Sync,
     ActivatePanel(null),
     Notify(localize('Recipe Added'))
   ]);
@@ -398,7 +397,13 @@ const templateAllDocsUrl = origin =>
     origin_url: origin
   });
 
-const templateRecipesDatabase = origin =>
+const templateRecipePut = (origin, id) =>
+  Template.render(Config.recipes.doc, {
+    origin_url: origin,
+    id
+  });
+
+const templateRecipesDb = origin =>
   Template.render(Config.recipes.origin, {
     origin_url: origin
   });

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -10,7 +10,6 @@ import {merge, tag, tagged, batch, annotate, port} from './common/prelude';
 import * as Modal from './common/modal';
 import {cursor} from './common/cursor';
 import {classed, toggle} from './common/attr';
-import * as Progress from './common/progress';
 import {localize} from './common/lang';
 import {compose, constant} from './lang/functional';
 import * as RecipesForm from './recipes/form';
@@ -32,20 +31,6 @@ const TagBanner = source => ({
   source
 });
 
-const TagProgress = source => ({
-  type: 'Progress',
-  source
-});
-
-const Loading = TagProgress(Progress.Loading);
-const Loaded = TagProgress(Progress.Loaded);
-
-// Attempt to publish a recipe to the database.
-const Publish = recipe => ({
-  type: 'Publish',
-  recipe
-});
-
 const Notify = compose(TagBanner, Banner.Notify);
 const AlertRefreshable = compose(TagBanner, Banner.AlertRefreshable);
 const AlertDismissable = compose(TagBanner, Banner.AlertDismissable);
@@ -54,9 +39,11 @@ const FailRecipeStart = AlertDismissable("Couldn't start recipe");
 const TagRecipesForm = action =>
   action.type === 'Back' ?
   ActivatePanel(null) :
-  action.type === 'Submitted' ?
-  Publish(action.recipe) :
+  action.type === 'ReceiptAddRecipe' ?
+  ReceiptAddRecipe(action.recipe) :
   RecipesFormAction(action);
+
+const ConfigureRecipesForm = compose(TagRecipesForm, RecipesForm.Configure);
 
 const RecipesFormAction = action => ({
   type: 'RecipesForm',
@@ -85,25 +72,23 @@ export const Configure = origin => ({
   origin
 });
 
+const ReceiptAddRecipe = recipe => ({
+  type: 'ReceiptAddRecipe',
+  recipe
+});
+
+// Insert recipe into model
+const InsertRecipe = recipe => ({
+  type: 'InsertRecipe',
+  recipe
+});
+
 // Restore recipes by fetching over HTTP
 const RestoreRecipes = {type: 'RestoreRecipes'};
 
 // Response from recipe restore
 const RestoredRecipes = result => ({
   type: 'RestoredRecipes',
-  result
-});
-
-// Put request action
-const Put = (url, body) => ({
-  type: 'Put',
-  url,
-  body
-});
-
-// Put request response
-const Putted = result => ({
-  type: 'Putted',
   result
 });
 
@@ -140,7 +125,6 @@ const NoOp = Indexed.NoOp;
 export const init = () => {
   const [recipesForm, recipesFormFx] = RecipesForm.init();
   const [banner, bannerFx] = Banner.init();
-  const [progress, progressFx] = Progress.init();
 
   return [
     {
@@ -154,13 +138,11 @@ export const init = () => {
       // Index all recipes by ID
       entries: {},
       recipesForm,
-      banner,
-      progress
+      banner
     },
     Effects.batch([
       recipesFormFx.map(TagRecipesForm),
-      bannerFx.map(TagBanner),
-      progressFx.map(TagProgress)
+      bannerFx.map(TagBanner)
     ])
   ];
 };
@@ -180,13 +162,6 @@ const updateBanner = cursor({
   set: (model, banner) => merge(model, {banner}),
   update: Banner.update,
   tag: TagBanner
-});
-
-const updateProgress = cursor({
-  get: model => model.progress,
-  set: (model, progress) => merge(model, {progress}),
-  update: Progress.update,
-  tag: TagProgress
 });
 
 const updateRecipesForm = cursor({
@@ -210,13 +185,25 @@ const restoredOk = (model, resp) => {
     // Index all recipes by ID
     entries: Indexed.indexByID(recipes)
   });
-  return update(next, Loaded);
+  return [next, Effects.none];
 }
 
 const restoredError = (model, error) => {
   const message = localize("Hmm, couldn't read from your browser's database.");
   return update(model, AlertRefreshable(message));
 }
+
+const receiptAddRecipe = (model, value) =>
+  batch(update, model, [
+    InsertRecipe(model, recipe),
+    ActivatePanel(null),
+    Notify(localize('Recipe Added'))
+  ]);
+
+const insertRecipe = (model, recipe) => [
+  Indexed.insert(model, recipe._id, recipe, Indexed.compareValue),
+  Effects.none
+];
 
 // Activate recipe by id
 const startByID = (model, id) => {
@@ -237,34 +224,12 @@ const startByID = (model, id) => {
 const activatePanel = (model, id) =>
   [merge(model, {activePanel: id}), Effects.none];
 
-const publish = (model, recipe) =>
-  batch(update, model, [
-    Loading,
-    Put(templateRecipePut(model.origin, recipe._id), recipe)
-  ]);
-
-const put = (model, url, body) => [
-  model,
-  Request.put(url, body).map(Putted)
-];
-
-const puttedOk = (model, value) =>
-  batch(update, model, [
-    ClearRecipesForm,
-    RestoreRecipes,
-    ActivatePanel(null),
-    Notify(localize('Recipe Added'))
-  ]);
-
-const puttedError = (model, error) =>
-  batch(update, model, [
-    Loaded,
-    AlertRecipesForm(String(error))
-  ]);
-
 const configure = (model, origin) => {
   const next = merge(model, {origin});
-  return update(next, RestoreRecipes);
+  return batch(update, next, [
+    RestoreRecipes,
+    ConfigureRecipesForm(origin)
+  ]);
 }
 
 export const update = (model, action) =>
@@ -278,18 +243,6 @@ export const update = (model, action) =>
   updateModal(model, action.source) :
   action.type === 'NoOp' ?
   [model, Effects.none] :
-  action.type === 'Publish' ?
-  publish(model, action.recipe) :
-  action.type === 'Progress' ?
-  updateProgress(model, action.source) :
-  action.type === 'Put' ?
-  put(model, action.url, action.body) :
-  action.type === 'Putted' ?
-  (
-    action.result.isOk ?
-    puttedOk(model, action.result.value) :
-    puttedError(model, action.result.error)
-  ) :
   action.type === 'RestoreRecipes' ?
   restore(model) :
   action.type === 'RestoredRecipes' ?
@@ -298,6 +251,10 @@ export const update = (model, action) =>
     restoredOk(model, action.result.value) :
     restoredError(model, action.result.error)
   ) :
+  action.type === 'ReceiptAddRecipe' ?
+  receiptAddRecipe(model, action.recipe) :
+  action.type === 'InsertRecipe' ?
+  insertRecipe(model, action.recipe) :
   action.type === 'StartByID' ?
   startByID(model, action.id) :
   action.type === 'ActivatePanel' ?
@@ -327,12 +284,6 @@ export const view = (model, address) => {
       }),
       open: toggle(model.isOpen, 'open')
     }, [
-      thunk(
-        'recipes-progress',
-        Progress.view,
-        model.progress,
-        forward(address, TagProgress)
-      ),
       html.div({
         className: classed({
           'panels--main': true,
@@ -404,10 +355,4 @@ const onRecipeForm = port(event => {
 const templateAllDocsUrl = origin =>
   Template.render(Config.recipes.all_docs, {
     origin_url: origin
-  });
-
-const templateRecipePut = (origin, id) =>
-  Template.render(Config.recipes.doc, {
-    origin_url: origin,
-    id
   });

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -411,8 +411,3 @@ const templateRecipePut = (origin, id) =>
     origin_url: origin,
     id
   });
-
-const templateRecipesDb = origin =>
-  Template.render(Config.recipes.origin, {
-    origin_url: origin
-  });

--- a/scripts/recipes.js
+++ b/scripts/recipes.js
@@ -200,10 +200,13 @@ const addedRecipe = (model, recipe) =>
     Notify(localize('Recipe Added'))
   ]);
 
-const insertRecipe = (model, recipe) => [
-  Indexed.insert(model, recipe._id, recipe, Indexed.compareValue),
-  Effects.none
-];
+const insertRecipe = (model, recipe) => {
+  const item = Recipe.fromDoc(recipe);
+  return [
+    Indexed.insert(model, item.id, item),
+    Effects.none
+  ];
+}
 
 // Activate recipe by id
 const startByID = (model, id) => {


### PR DESCRIPTION
## Motivation

Sync between PouchDB and CouchDB was a rather complicated code path, and certain cases were getting missed.

- Recipes deleted in one place could remain in another. Deletes were not always reflected.
- Occasionally, Pouch would refuse to sync with recipes DB, even if DB was accessible.

This PR removes the PouchDB layer and communicates with the recipes DB directly.

## Rational

- Simplifies the code path, simplifies reasoning.
- The recipe data coming from CouchDB is small and latency is typically very low.
- The UI is served from the Pi, which also hosts the DB. Having Pouch offline-accessible doesn't make much of a difference for recipes, since to see the UI and access a recipe in the DB, you have to have access to the Pi anyway.

This also happens to remove one of the two places we were using PouchDB. If we can eliminate Pouch, we can remove a large chunk of bulk from our compiled code.