### PR TITLE
Add CSV export for all variables

### DIFF
--- a/openag-config.json
+++ b/openag-config.json
@@ -15,6 +15,7 @@
     "origin_latest": "{{origin_url}}/environmental_data_point/_design/openag/_view/by_variable?group_level=3&startkey={{startkey}}&endkey={{endkey}}",
     "origin_range": "{{origin_url}}/environmental_data_point/_design/openag/_view/by_timestamp?startkey={{startkey}}&endkey={{endkey}}&limit={{limit}}&descending={{descending}}&stale=update_after",
     "origin_by_variable_csv": "{{origin_url}}/environmental_data_point/_design/openag/_list/csv/by_variable?group_level={{group_level}}&startkey={{startkey}}&endkey={{endkey}}&limit={{limit}}&descending={{descending}}&stale=update_after",
+    "origin_all_csv": "{{origin_url}}/environmental_data_point/_design/openag/_list/csv/all_vars?group_level={{group_level}}&limit={{limit}}&descending={{descending}}&stale=update_after",
     "timelapse": "{{origin_url}}/environmental_data_point/{{recipe_start_id}}/timelapse",
     "image": "{{origin_url}}/environmental_data_point/{{id}}/image",
     "changes": "{{origin_url}}/environmental_data_point/_changes?feed=longpoll&include_docs=true&heartbeat=true&since=now"

--- a/scripts/environment/exporter.js
+++ b/scripts/environment/exporter.js
@@ -88,12 +88,15 @@ export const view = (model, address, environmentID) => {
               {
                 className: 'menu-list'
               },
-              Config.chart.map(config => renderExport(
-                model.origin,
-                environmentID,
-                config.variable,
-                config.title
-              ))
+              [renderExportAll(model.origin, environmentID)].concat(
+                Config.chart.map(config => renderExport(
+                  model.origin,
+                  environmentID,
+                  config.variable,
+                  config.title
+                  )
+                )
+              )
             )
           ])
         ])
@@ -114,11 +117,30 @@ const renderExport = (origin, environmentID, variable, title) =>
     ])
   ]);
 
+const renderExportAll = (origin, environmentID) =>
+  html.li(null, [
+    html.a({
+      target: '_blank',
+      href: templateCsvUrlAll(origin, environmentID)
+    }, [
+      "All Variables"
+      ]
+    )
+  ]);
+
 const templateCsvUrl = (origin, environmentID, variable) =>
   Template.render(Config.environmental_data_point.origin_by_variable_csv, {
     origin_url: origin,
     startkey: JSON.stringify([environmentID, 'measured', variable, {}]),
     endkey: JSON.stringify([environmentID, 'measured', variable]),
+    limit: MAX_DATAPOINTS,
+    group_level: 4,
+    descending: true
+  });
+
+const templateCsvUrlAll = (origin, environmentID) =>
+  Template.render(Config.environmental_data_point.origin_all_csv, {
+    origin_url: origin,
     limit: MAX_DATAPOINTS,
     group_level: 4,
     descending: true


### PR DESCRIPTION
The current CSV exporter can only export one environmental variable type at a time.
I added support for an all variable CSV exporter.

This PR relies on https://github.com/OpenAgInitiative/openag_brain/pull/288 in a separate repo, and a more detailed writeup has been done there.