### PR TITLE
Fix arguments for couchapp_deploy grunt task

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sudo apt-get install -y nodejs`
 ```
 $ cd openag_ui
 $ npm install
-$ npm run couchapp_deploy --app_db_url="http://localhost:5984/app"
+$ npm run couchapp_deploy -- --app_db_url="http://localhost:5984/app"
 ```
 ### Access the UI
 Open your browser to `http://${IP_OF_FOOD_COMPUTER}:5984/app/_design/app/_rewrite`.
@@ -85,7 +85,7 @@ Deploying CouchApp
 
 When doing development, you can deploy the result as a "CouchApp" -- a set of attachments stored in a CouchDB design document. This is how we host the UI on the Food Computer.
 
-    npm run couchapp_deploy --app_db_url="http://localhost:5984/app"
+    npm run couchapp_deploy -- --app_db_url="http://localhost:5984/app"
 
 The `app_db_url` parameter is optional, and will default to `http://raspberrypi:5984/app`.
 The UI should be available at `http://${IP_OF_FOOD_COMPUTER}:5984/app/_design/app/_rewrite`


### PR DESCRIPTION
As @Spaghet pointed out, the grunt task wasn't getting the arguments passed
correctly by npm. By delimiting the  `npm run` command and options with a `--` we can
properly pass those arguments to the grunt script.

https://docs.npmjs.com/cli/run-script

Fixes https://github.com/OpenAgInitiative/openag_ui/issues/148