### PR TITLE
Fix status code 400 in stop_recipe service call

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -297,7 +297,7 @@ const postStopStartRecipe = (model, environmentID, id) => {
 
   return [
     model,
-    Request.post(url, {}).map(RecipeStopStartPosted)
+    Request.post(url, null).map(RecipeStopStartPosted)
   ];
 }
 


### PR DESCRIPTION
The stop_recipe service requests an Empty message body, but we were sending a `{}`, which registered as `[[]]` in ROS.

